### PR TITLE
Bug小修复

### DIFF
--- a/library/src/main/java/me/drakeet/library/UIButton.java
+++ b/library/src/main/java/me/drakeet/library/UIButton.java
@@ -48,15 +48,18 @@ public class UIButton extends UIBaseButton {
 
     public UIButton(Context context, AttributeSet attrs) {
         super(context, attrs);
+		init(context, attrs);
     }
 
     public UIButton(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+		init(context, attrs);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public UIButton(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+		init(context, attrs);
     }
 
     @Override

--- a/library/src/main/java/me/drakeet/library/UIRippleButton.java
+++ b/library/src/main/java/me/drakeet/library/UIRippleButton.java
@@ -114,9 +114,9 @@ public class UIRippleButton extends UIBaseButton {
         if (canvas != null && pointX >= 0 && pointY >= 0){
             int rbX = canvas.getWidth();
             int rbY = canvas.getHeight();
-            float longDis = Math.max(pointX, pointY);
-            longDis = Math.max(longDis, Math.abs(rbX - pointX));
-            longDis = Math.max(longDis, Math.abs(rbY - pointY));
+            float x_max =  Math.max(pointX, Math.abs(rbX - pointX));
+            float y_max =  Math.max(pointY, Math.abs(rbY - pointY));
+            float longDis = (float) Math.sqrt(x_max*x_max+y_max*y_max);
             if (mRippleRadius > longDis) {
                 onCompleteDrawRipple();
                 return;


### PR DESCRIPTION
在使用过程中，发现两个小Bug，以下：
1UIButton中： alpha_pressed设置无效，原因：构造函数没初始化，加上init(context, attrs)就OK了；
2UIRippleButton中，当RippleEffect波纹无法到达最远的边缘点。以前的longDis计算的只是距离点击点最远边的距离，其实离某一个角的距离才是最远。勾股定理计算：
float x_max =  Math.max(pointX, Math.abs(rbX - pointX));
float y_max =  Math.max(pointY, Math.abs(rbY - pointY));
float longDis = (float) Math.sqrt(x_max*x_max+y_max*y_max);