### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Hope you will like it :)
 
 ## Usage
 ### Step 1
-####Gradle & Maven
+#### Gradle & Maven
 ```groovy
 dependencies {
     compile 'me.drakeet.uiview:androiduiview:1.1.5'
@@ -36,7 +36,7 @@ dependencies {
 ```
 
 
-####Or
+#### Or
 
 Import the library, then add it to your `/settings.gradle` and `/app/build.gradle`, if you don't know how to do it, you can read my blog for help.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
